### PR TITLE
Apprentice reviews should be anonymous

### DIFF
--- a/markdown/assessment.md
+++ b/markdown/assessment.md
@@ -43,8 +43,8 @@ To setup the assessment, go to [the Namely Review Creation page][reviews].
 
 ## Permission Options
 
-* Hide Reviewers' Identities From One Another: Unchecked
-* Make Totally Anonymous Review: Unchecked
+* Hide Reviewers' Identities From One Another: **Checked**
+* Make Totally Anonymous Review: **Checked**
 
 ## Summarization Options
 


### PR DESCRIPTION
Our quarterly reviews are anonymous, and the Namely instructions in the apprentice's review that's sent out to reviewers say "This assessment is anonymous."

This is not reflected in these assessment instructions currently.