### PR TITLE
Fix onboarding formatting

### DIFF
--- a/onboarding-packet.md
+++ b/onboarding-packet.md
@@ -138,9 +138,9 @@ available at https://github.com/thoughtbot/laptop.
 
 ### Dotfiles
 
-Dotfiles are the files in your home directory (referred to as "~") that start
-with a dot, like "~/.bashrc". They are used to configure various programs, e.g.
-"~/.vimrc" sets some global options for Vim. Take a look at thoughtbot's
+Dotfiles are the files in your home directory (referred to as `~`) that start
+with a dot, like `~/.bashrc`. They are used to configure various programs, e.g.
+`~/.vimrc` sets some global options for Vim. Take a look at thoughtbot's
 dotfiles (https://github.com/thoughtbot/dotfiles), and feel free to fork them.
 We also encourage you to check out your coworkers' dotfiles for inspiration. For
 example, Josh Clayton has an extensive configuration for tmux in his dotfiles:


### PR DESCRIPTION
## Problem

In the "Dotfiles" section of the onboarding packet, names of system directories and files were in quotes, causing the "~" to denote markdown strikethrough formatting, not the Unix home directory:
<img width="598" alt="screen shot 2017-06-12 at 4 49 03 pm" src="https://user-images.githubusercontent.com/12753198/27054551-5c1a45fe-4f8f-11e7-9a60-c229b9cd2aef.png">

## Solution

This PR wraps those names in code blocks to prevent strange
formatting mishaps.

<img width="692" alt="screen shot 2017-06-12 at 4 53 03 pm" src="https://user-images.githubusercontent.com/12753198/27054652-a6ee8afe-4f8f-11e7-9cdc-296b13f6b9e7.png">
