### PR TITLE
Fix markdown formatting bugs

### DIFF
--- a/onboarding-packet.md
+++ b/onboarding-packet.md
@@ -141,13 +141,13 @@ available at [https://github.com/thoughtbot/laptop].
 
 ### Dotfiles
 
-Dotfiles are the files in your home directory (referred to as "~") that start
-with a dot, like "~/.bashrc". They are used to configure various programs, e.g.
-"~/.vimrc" sets some global options for Vim. Take a look at [thoughtbot's
+Dotfiles are the files in your home directory (referred to as "\~") that start
+with a dot, like "\~/.bashrc". They are used to configure various programs, e.g.
+"\~/.vimrc" sets some global options for Vim. Take a look at [thoughtbot's
 dotfiles](https://github.com/thoughtbot/dotfiles), and feel free to fork them.
 We also encourage you to check out your coworkers' dotfiles for inspiration. For
-example, Josh Clayton has an extensive configuration for tmux in [his dotfiles]
-(https://github.com/joshuaclayton/dotfiles/blob/master/tmux.conf).
+example, Josh Clayton has an extensive configuration for tmux in
+[his dotfiles](https://github.com/joshuaclayton/dotfiles/blob/master/tmux.conf).
 
 ## Logins
 


### PR DESCRIPTION
- Left unescaped, the tildes representing the home directory get
interpreted in markdown as strikethroughs:

<img width="395" alt="screen shot 2018-04-29 at 10 06 40 pm" src="https://user-images.githubusercontent.com/13696143/39413664-d8a9ba5a-4bfb-11e8-9560-ff70b330c009.png">

- The newline between the brackets and parentheses seems to have disrupted
the formatting of this link:

<img width="577" alt="screen shot 2018-04-29 at 10 15 41 pm" src="https://user-images.githubusercontent.com/13696143/39413666-de09e902-4bfb-11e8-8ac2-f86f90a14886.png">